### PR TITLE
fix(dns): pin dotnet version

### DIFF
--- a/dns/Dockerfile
+++ b/dns/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x \
         curl \
         icu-devtools \
         wget \
-    && curl --proto "=https" --tlsv1.2 -sSf -L https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir /opt/dotnet --channel LTS --version latest --runtime aspnetcore \
+    && curl --proto "=https" --tlsv1.2 -sSf -L https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir /opt/dotnet --channel 9.0 --version latest --runtime aspnetcore \
     && curl --proto "=https" --tlsv1.2 -sSf -L https://download.technitium.com/dns/DnsServerPortable.tar.gz -o /tmp/DnsServerPortable.tar.gz \
     && mkdir -p /opt/dns \
     && tar -zxf DnsServerPortable.tar.gz -C /opt/dns/ \


### PR DESCRIPTION
Fixes https://github.com/velvet-lab/hassio-addons/issues/3
The docker image wasn't pinned to a major version, so when rebuilding the add-on it would cause the wrong version of dotnet to be installed. 

symptoms of the problem:
<img width="1157" height="303" alt="image" src="https://github.com/user-attachments/assets/9a86d6b7-b9de-453b-919d-578c061877e8" />


proof of fix:
<img width="766" height="560" alt="image" src="https://github.com/user-attachments/assets/e3ee8719-dc98-425b-a89b-f40a4d131287" />
